### PR TITLE
use dynaconf for config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 **/__pycache__
 **/build
 
-/config.py
+/config.toml
 /.data
 
 Pipfile

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,0 +1,31 @@
+[server]
+debug = false
+domain = "CHANGE THIS"
+port = 1000
+
+[database]
+host = "localhost"
+user = "CHANGE THIS"
+password = "CHANGE THIS"
+db = "CHANGE THIS"
+autocommit = true
+
+[redis]
+host = "localhost"
+username = "CHANGE THIS IF ANYTHING"
+password = "CHANGE THIS IF ANYTHING"
+port = 6379
+
+[api]
+key = "CHANGE THIS"
+
+[api.mirrors]
+chimu = "https://api.chimu.moe/v1/"
+katsu = "https://katsu.moe/"
+nerinyan = "https://api.nerinyan.moe/"
+
+[discord]
+token = "CHANGE THIS"
+
+[fun]
+rank_all_maps = true

--- a/constants/commands.py
+++ b/constants/commands.py
@@ -633,7 +633,7 @@ async def change_size(ctx: Context) -> str | None:
 @ensure_match(host=False)
 async def get_beatmap(ctx: Context) -> str | None:
     m = ctx.author.match
-    mirrors = services.config["api_conf"]["mirrors"]
+    mirrors = services.config.api.mirrors
 
     if not ctx.args:
         return f"Wrong usage: !mp get <{'|'.join(mirrors.keys())}>"

--- a/lib/database.py
+++ b/lib/database.py
@@ -1,13 +1,20 @@
 from typing import Any, AsyncIterable, Optional
 import aiomysql
+from dynaconf import Dynaconf
 
 
 class Database:
     def __init__(self):
         self.pool = None
 
-    async def connect(self, config: dict[str, str]) -> None:
-        self.pool = await aiomysql.create_pool(**config)
+    async def connect(self, config: Dynaconf) -> None:
+        self.pool = await aiomysql.create_pool(
+            host=config.host,
+            user=config.user,
+            password=config.password,
+            db=config.db,
+            autocommit=config.autocommit,
+        )  # type: ignore
 
     async def disconnect(self) -> None:
         self.pool.close()

--- a/objects/beatmap.py
+++ b/objects/beatmap.py
@@ -138,7 +138,7 @@ class Beatmap:
         b.mode = ret["mode"]
         b.bpm = ret["bpm"]
 
-        if services.config["fun"]["rank_all_maps"]:
+        if services.config.fun.rank_all_maps:
             b.approved = Approved.RANKED
         else:
             b.approved = Approved(ret["approved"])
@@ -230,7 +230,7 @@ class Beatmap:
         )  # fix taiko and mania "null" combo
 
         # for some reason, the api shows approved as one behind?
-        if services.config["fun"]["rank_all_maps"]:
+        if services.config.fun.rank_all_maps:
             b.approved = Approved.RANKED
         else:
             if (ranked_status := Approved(int(ret["approved"]))) <= Approved.PENDING:

--- a/objects/bot.py
+++ b/objects/bot.py
@@ -40,7 +40,7 @@ class Bot(Player):
         bot.discord = discord.Client(intents=intents)
 
         try:
-            await bot.discord.login(services.config["discord"]["token"])
+            await bot.discord.login(services.config.discord.token)
         except discord.LoginFailure:
             log.fail("✗ Failed to login into discord bot (invalid token).")
             sys.exit()
@@ -66,7 +66,8 @@ class Bot(Player):
         )
 
         flag_count = await services.sql.fetch(
-            "SELECT COUNT(*) AS count FROM anticheat WHERE user_id = %s", (score.player.id)
+            "SELECT COUNT(*) AS count FROM anticheat WHERE user_id = %s",
+            (score.player.id),
         )
 
         GUILD_ID = 483250302800101376

--- a/objects/services.py
+++ b/objects/services.py
@@ -1,31 +1,40 @@
+import os
 import re
+import sys
+import tomllib
+
 
 from typing import Any, Pattern, TYPE_CHECKING
 
 from attr import dataclass
-from config import conf
+from dynaconf import Dynaconf
 from redis import asyncio as aioredis
 
 from lib.database import Database
 from objects.achievement import Achievement
+from utils import log
 
 if TYPE_CHECKING:
     from objects.collections import Tokens, Channels, Matches, Beatmaps
     from packets.reader import Packet
     from objects.bot import Bot
 
+if not os.path.exists("config.toml"):
+    os.rename("config.example.toml", "config.toml")
+    log.warn("You have to edit the config.toml!")
+    sys.exit(1)
 
-debug: bool = conf["server"]["debug"]
-domain: str = conf["server"]["domain"]
-port: int = conf["server"]["port"]
+config: Dynaconf = Dynaconf(settings_files=["config.toml"])
+
+debug: bool = config.server.debug
+domain: str = config.server.domain
+port: int = config.server.port
 
 packets: dict[int, "Packet"] = {}
 
 bot: "Bot"
 
 prefix: str = "!"
-
-config: dict[str, dict[str, Any]] = conf
 
 
 @dataclass
@@ -91,7 +100,7 @@ channels: "Channels"
 matches: "Matches"
 beatmaps: "Beatmaps"
 
-osu_key: str = config["api_conf"]["osu_api_key"]
+osu_key: str = config.api.key
 
 achievements: list[Achievement] = []
 

--- a/server.py
+++ b/server.py
@@ -29,7 +29,6 @@ from utils import log
 from redis import asyncio as aioredis
 
 import os
-import sys
 import tasks
 
 REQUIRED_DIRECTORIES = (
@@ -41,7 +40,7 @@ REQUIRED_DIRECTORIES = (
 )
 
 
-async def startup():
+async def startup() -> None:
     print(f"\033[94m{services.title_card}\033[0m")
 
     services.players = Tokens()
@@ -61,14 +60,14 @@ async def startup():
     log.info("... Connecting to the database")
 
     services.sql = Database()
-    await services.sql.connect(services.config["mysql"])
+    await services.sql.connect(services.config.database)
 
     log.info("✓ Connected to the database!")
     log.info("... Initalizing redis")
 
-    redisconf = services.config["redis"]
+    redisconf = services.config.redis
     services.redis = aioredis.from_url(
-        f"redis://{redisconf['username']}:{redisconf['password']}@{redisconf['host']}:{redisconf['port']}"
+        f"redis://{redisconf.username}:{redisconf.password}@{redisconf.host}:{redisconf.port}"
     )
     await services.redis.initialize()
 


### PR DESCRIPTION
#18 

Instead of using a python dictionary and calling values like config["server"], we now use TOML and dynaconf so values can be called like config.server instead.