### PR TITLE
implement proper client version check and speed up startup a bit

### DIFF
--- a/events/bancho.py
+++ b/events/bancho.py
@@ -188,10 +188,9 @@ async def login(req: Request) -> Response:
     if not user_info["privileges"] & Privileges.VERIFIED | Privileges.PENDING:
         data += writer.notification(RESTRICTED_MSG)
 
-    # TODO: actual implement this check properly wtf
-    # only allow 2023 clients
-    # if not client_info[0].startswith("b2023"):
-    #     return failed_login(LoginResponse.INVALID_CLIENT)
+    # remove the little b infront of the version
+    if client_info[0][1:] not in services.ALLOWED_BUILDS:
+        return failed_login(LoginResponse.INVALID_CLIENT)
 
     # check if the user is banned.
     if user_info["privileges"] & Privileges.BANNED:

--- a/objects/services.py
+++ b/objects/services.py
@@ -120,3 +120,5 @@ regex: dict[str, Pattern[str]] = {
 
 # {token: "message"}
 await_response: dict[str, str] = {}
+
+ALLOWED_BUILDS: list[str] = []

--- a/tasks.py
+++ b/tasks.py
@@ -1,7 +1,11 @@
 from dataclasses import dataclass
 from typing import Callable
+
+import aiohttp
 from constants.player import bStatus
 from objects import services
+from objects.achievement import Achievement
+from objects.channel import Channel
 from utils import log
 
 import time
@@ -49,7 +53,7 @@ async def check_for_osu_settings_update() -> None:
     await services.osu_settings.initialize_from_db()
 
 
-async def run_all_tasks():
+async def run_all_tasks() -> None:
     while True:
         for task in tasks:
             if time.time() - task.last_called >= task.delay:
@@ -58,3 +62,64 @@ async def run_all_tasks():
                 task.last_called = time.time()
 
         await asyncio.sleep(0.1)
+
+
+ALLOWED_STREAMS = ("stable40", "cuttingedge", "beta")
+
+
+# pretty ugly
+async def cache_allowed_osu_builds() -> None:
+    versions = []
+
+    async with aiohttp.ClientSession() as session:
+        async with session.get("https://osu.ppy.sh/api/v2/changelog") as response:
+            data = await response.json()
+
+            for stream in data["streams"]:
+                if stream["name"] not in ALLOWED_STREAMS:
+                    continue
+
+                match stream["name"]:
+                    case "beta40":
+                        suffix = "beta"
+                    case "cuttingedge":
+                        suffix = "cuttingedge"
+                    case _:
+                        suffix = ""
+
+                versions.append(stream["latest_build"]["version"] + suffix)
+
+            for build in data["builds"]:
+                if build["update_stream"]["name"] not in ALLOWED_STREAMS:
+                    continue
+
+                match build["update_stream"]["name"]:
+                    case "beta40":
+                        suffix = "beta"
+                    case "cuttingedge":
+                        suffix = "cuttingedge"
+                    case _:
+                        suffix = ""
+
+                versions.append(build["version"] + suffix)
+
+    services.ALLOWED_BUILDS = versions
+
+
+async def cache_channels() -> None:
+    async for _channel in services.sql.iterall(
+        "SELECT name, description, public, staff, auto_join, read_only FROM channels"
+    ):
+        channel = Channel(**_channel)
+        services.channels.add(channel)
+
+
+async def cache_achievements() -> None:
+    async for achievement in services.sql.iterall("SELECT * FROM achievements"):
+        services.achievements.append(Achievement(**achievement))
+
+
+async def run_cache_task() -> None:
+    await asyncio.gather(
+        *[cache_allowed_osu_builds(), cache_achievements(), cache_channels()]
+    )


### PR DESCRIPTION
closes #17 

Before we checked which year the build was from (were "b2023"), which is not sustainable as it'd need to be updated every year. On top of that, client as old as up to 11 months were allowed in, which shouldn't in my opinion. This change looks at the osu api and takes the 2 latests build from the allowed streams (stable and cutting edge).